### PR TITLE
Update to enable use on praw 6 & support for custom usernote types

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ un.set_json("Pruned users via puni")
 ```
 
 **Custom Usernotes**:
+
 additional usernote types can be added through a puni.ini file in the current working directory. It should be in the following format:
 
 ```ini

--- a/README.md
+++ b/README.md
@@ -72,3 +72,13 @@ for user in un.get_users():
 # Now update the usernotes
 un.set_json("Pruned users via puni")
 ```
+
+**Custom Usernotes**:
+additional usernote types can be added through a puni.ini file in the current working directory. It should be in the following format:
+
+```ini
+[USERNOTES]
+noteType1 = watch
+noteType2 = messaged
+noteType3 = warning
+```

--- a/puni/base.py
+++ b/puni/base.py
@@ -21,6 +21,7 @@ import re
 import zlib
 import base64
 import copy
+import configparser
 
 from prawcore.exceptions import NotFound
 from puni.decorators import update_cache
@@ -29,16 +30,13 @@ from puni.decorators import update_cache
 class Note(object):
     """Represents an individual usernote."""
 
-    warnings = [
-        'none',
-        'spamwatch',
-        'spamwarn',
-        'abusewarn',
-        'ban',
-        'permban',
-        'botban',
-        'gooduser'
-    ]
+    config = configparser.ConfigParser()
+    warnings = [ 'none', 'spamwatch', 'spamwarn', 'abusewarn', 'ban', 'permban', 'botban', 'gooduser']
+    try:
+        config.read('puni.ini')
+        for key in config['USERNOTES']: warnings.append(config['USERNOTES'][key])
+    except:
+        pass
 
     def __init__(self, user, note, subreddit=None, mod=None, link='',
                  warning='none', note_time=None):

--- a/puni/version.py
+++ b/puni/version.py
@@ -14,4 +14,4 @@ details. You should have received a copy of the GNU General Public License along
 with puni. If not, see http://www.gnu.org/licenses/.
 """
 
-__version__ = '1.1.2'
+__version__ = '1.1.3'

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     license='GPLv3',
     packages=[PACKAGE_NAME],
     install_requires=[
-        'praw >=4.0, <6.0',
+        'praw >=4.0, <7.0',
     ],
     tests_require=[
         'nose',


### PR DESCRIPTION
puni works fine with the 6.x branch of praw, but current installation limitations won't let it run.

Additionally, I needed to support custom note types for my subreddit (as we pretty much completely ignore the default types), so I added in the ability to read additional note types from an ini in the working directory. I'm *very* bad with python, so this might not be anything close to best practice, but it was what I could come up with.