### PR TITLE
support custom usernote types with a puni.ini file

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,7 @@ for user in un.get_users():
 # Now update the usernotes
 un.set_json("Pruned users via puni")
 ```
+
+**Custom Usernotes**:
+
+custom usernote types can be defined in a puni.ini file in the directory a script using puni is located in. An example puni.ini file may be found [here](puni.ini.example)

--- a/puni.ini.example
+++ b/puni.ini.example
@@ -1,0 +1,7 @@
+[USERNOTES]
+gooduser = gooduser
+watch = watch
+messaged = messaged
+warning = warning
+tempban = tempban
+permban = permban

--- a/puni/base.py
+++ b/puni/base.py
@@ -21,6 +21,7 @@ import re
 import zlib
 import base64
 import copy
+import configparser
 
 from prawcore.exceptions import NotFound
 from puni.decorators import update_cache
@@ -29,16 +30,23 @@ from puni.decorators import update_cache
 class Note(object):
     """Represents an individual usernote."""
 
-    warnings = [
-        'none',
-        'spamwatch',
-        'spamwarn',
-        'abusewarn',
-        'ban',
-        'permban',
-        'botban',
-        'gooduser'
-    ]
+    warnings = []
+    try:
+        config = configparser.ConfigParser()
+        config.read('puni.ini')
+        for key in config['USERNOTES']:
+            warnings.append(config['USERNOTES'][key])
+    except:
+        warnings = [
+            'none',
+            'spamwatch',
+            'spamwarn',
+            'abusewarn',
+            'ban',
+            'permban',
+            'botban',
+            'gooduser'
+        ]
 
     def __init__(self, user, note, subreddit=None, mod=None, link='',
                  warning='none', note_time=None):


### PR DESCRIPTION
Essentially a more granular version of [this](https://github.com/danthedaniel/puni/pull/7) closed pull request, just adding the ability to use a puni.ini file to define custom note types through an ini file, and falling back to defaults if none are found.