### PR TITLE
Update max praw version to 8.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     license='GPLv3',
     packages=[PACKAGE_NAME],
     install_requires=[
-        'praw >=4.0, <=7.1.0',
+        'praw >=4.0, <=8.0',
     ],
     tests_require=[
         'nose',


### PR DESCRIPTION
praw is currently on version 7.2.0; puni works fine under it. There won't be breaking changes in minor point versions, so there's no need to specify maximum minor versions.